### PR TITLE
Fix global font usage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
## Summary
- apply Geist font across the site by default

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886afdda80c83288a1e4f16f8c2a6e0